### PR TITLE
Works for tables with or without complex headers

### DIFF
--- a/inst/htmlwidgets/lib/datatables-extensions/Buttons/js/buttons.html5.min.js
+++ b/inst/htmlwidgets/lib/datatables-extensions/Buttons/js/buttons.html5.min.js
@@ -543,7 +543,7 @@
                 z.appendChild(n);
               }
             }
-            if(z.children.length > 0)
+            if(z.children)
               g("worksheet", f).append(z)
             d = o(f, "cols");
             g("worksheet", f).prepend(d);


### PR DESCRIPTION
Undefined error raises when trying to export table with no complex headers.
Fixed this by changing z.children.length > 0 to be just a check on z.children exists and no longer raises undefined error.